### PR TITLE
Investigate nixpacks build failure no start command

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: sh -c 'PYTHONPATH=src uvicorn ea_importer.web.app:app --host 0.0.0.0 --port ${PORT:-8080}'


### PR DESCRIPTION
Add Procfile to provide an explicit start command for Nixpacks.

---
<a href="https://cursor.com/background-agent?bcId=bc-cc0659f7-5d28-4eda-9ec1-e5108a539887">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cc0659f7-5d28-4eda-9ec1-e5108a539887">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

