### PR TITLE
Fix nixpacks build no start command

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: PYTHONPATH=src uvicorn ea_importer.web.app:app --host 0.0.0.0 --port ${PORT:-8080}


### PR DESCRIPTION
Add `Procfile` with uvicorn start command to fix Nixpacks build failure due to missing start command.

---
<a href="https://cursor.com/background-agent?bcId=bc-6b593dd2-7b49-40a4-ac41-011e19c0ae4e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6b593dd2-7b49-40a4-ac41-011e19c0ae4e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

