### PR TITLE
Fix database connectivity for web UI

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -13,6 +13,7 @@ Set these in Railway project settings (Variables):
 - DB_CONNECT_TIMEOUT: `10` (optional)
 - DB_POOL_SIZE: `5` (recommended for small instances)
 - DB_MAX_OVERFLOW: `5`
+- DB_HOSTADDR: optional IPv4 literal for the DB host (e.g. `1.2.3.4`). If set, the app will connect to this address directly while keeping the hostname for TLS SNI via libpq's `host` field.
 
 The `Procfile` already binds Uvicorn to `0.0.0.0` and uses `PORT`, so no extra web vars are required.
 
@@ -31,7 +32,7 @@ From a local machine (or any environment with psql):
 psql "sslmode=require host=db.<ref>.supabase.co port=5432 dbname=postgres user=<user> password=<password>"
 ```
 
-If this works locally but fails on Railway with IPv6 addresses in logs, ensure `DB_PREFER_IPV4=true` is set.
+If this works locally but fails on Railway with IPv6 addresses in logs, ensure `DB_PREFER_IPV4=true` is set. If DNS still resolves to IPv6 only from within the container, set `DB_HOSTADDR` to the IPv4 address of your Supabase DB (you can resolve it locally: `dig +short A db.<ref>.supabase.co`).
 
 ### 4) Runtime behavior
 

--- a/src/ea_importer/core/config.py
+++ b/src/ea_importer/core/config.py
@@ -44,6 +44,7 @@ class DatabaseConfig(BaseSettings):
     keepalives_interval: int = Field(default=10, description="Seconds between keepalive probes")
     keepalives_count: int = Field(default=5, description="Number of failed keepalive probes before drop")
     prefer_ipv4: bool = Field(default=False, description="Prefer IPv4 addresses for database connections")
+    hostaddr: Optional[str] = Field(default=None, description="Optional IPv4 host address to bypass DNS/IPv6")
     
     class Config:
         env_prefix = "DB_"

--- a/src/ea_importer/database/__init__.py
+++ b/src/ea_importer/database/__init__.py
@@ -64,9 +64,13 @@ class DatabaseManager:
         if self.settings.database.sslmode:
             connect_args["sslmode"] = self.settings.database.sslmode
 
+        # Optional hostaddr override (forces IPv4 if provided)
+        if getattr(self.settings.database, "hostaddr", None):
+            connect_args["hostaddr"] = self.settings.database.hostaddr
+
         # Prefer IPv4: resolve host and supply hostaddr (libpq uses host for SNI)
         try:
-            if self.settings.database.prefer_ipv4:
+            if self.settings.database.prefer_ipv4 and "hostaddr" not in connect_args:
                 url = make_url(self.database_url)
                 if url.host:
                     infos = socket.getaddrinfo(url.host, url.port or 5432, family=socket.AF_INET, type=socket.SOCK_STREAM)

--- a/src/ea_importer/web/app.py
+++ b/src/ea_importer/web/app.py
@@ -21,6 +21,7 @@ import json
 import logging
 from pathlib import Path
 from datetime import datetime
+from sqlalchemy import text
 
 from ..core.config import get_settings
 from ..core.logging import get_logger
@@ -264,7 +265,7 @@ async def health_check():
     try:
         # Test database connection
         with get_db_session() as session:
-            session.execute("SELECT 1")
+            session.execute(text("SELECT 1"))
         
         return {
             "status": "healthy",


### PR DESCRIPTION
Add `DB_HOSTADDR` support to force IPv4 database connections and fix the health check's raw SQL expression.

The `DB_PREFER_IPV4` setting was insufficient to bypass IPv6 resolution issues on some hosting platforms, leading to "Network is unreachable" errors. `DB_HOSTADDR` allows direct IPv4 connection. Additionally, the health check endpoint was failing due to SQLAlchemy's requirement for explicit `text()` wrapping for raw SQL expressions.

---
<a href="https://cursor.com/background-agent?bcId=bc-cc04a263-674d-46f4-9df1-6069e2417e3e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cc04a263-674d-46f4-9df1-6069e2417e3e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

