### PR TITLE
Diagnose database connection error after commit

### DIFF
--- a/src/ea_importer/database/__init__.py
+++ b/src/ea_importer/database/__init__.py
@@ -116,7 +116,8 @@ class DatabaseManager:
         self.SessionLocal = sessionmaker(
             autocommit=False,
             autoflush=False,
-            bind=self.engine
+            bind=self.engine,
+            expire_on_commit=False,
         )
         
         logger.info("Database connection initialized successfully")


### PR DESCRIPTION
Set `expire_on_commit=False` in SQLAlchemy sessionmaker to prevent detached instance errors when accessing ORM objects in templates after a session commit.

ORM objects were queried within a session and then passed to Jinja templates. With the default `expire_on_commit=True`, attributes on these objects would expire after the session committed, leading to `Instance is not bound to a Session` errors when templates attempted to access them. This change ensures attributes remain accessible.

---
<a href="https://cursor.com/background-agent?bcId=bc-1c9b193f-a22c-4225-b8ac-6f6c1f8c9193">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1c9b193f-a22c-4225-b8ac-6f6c1f8c9193">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

